### PR TITLE
feat: Automatic error formatting in deep-nested objects

### DIFF
--- a/src/Logger.test.ts
+++ b/src/Logger.test.ts
@@ -502,6 +502,35 @@ describe('Logger', () => {
       ]);
     });
 
+    it('reformats error deep inside log objects', async () => {
+      const logger = Logger.create({
+        ...config,
+        errorFormatter: (err: Error) => ({
+          datMessage: err.message,
+          foo: 'bar',
+        }),
+      });
+      try {
+        throw new Error('Boom!');
+      } catch (err) {
+        logger.error('foo', { here: { is: { my: err } } });
+      }
+      logger.flush();
+
+      expectToHaveLogged([
+        {
+          here: {
+            is: {
+              my: {
+                datMessage: 'Boom!',
+                foo: 'bar',
+              },
+            },
+          },
+        },
+      ]);
+    });
+
     it('formats errors with custom errorFormatter', async () => {
       const logger = Logger.create({
         ...config,

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -152,6 +152,17 @@ export class Logger {
     };
   }
 
+  private _stringify(obj: object) {
+    const originalToJSON = (Error as any).prototype.toJSON;
+    const { errorFormatter } = this._config;
+    (Error as any).prototype.toJSON = function() {
+      return errorFormatter(this);
+    };
+    const stringified = JSON.stringify(obj);
+    (Error as any).prototype.toJSON = originalToJSON;
+    return stringified;
+  }
+
   private _log(logType: string, eventName: string, details?: object) {
     if (this._config.logToConsole) {
       console.log(logType, eventName, details || ''); // tslint:disable-line no-console
@@ -169,7 +180,7 @@ export class Logger {
     const finalEvent = this.interceptor ? this.interceptor(event) : event;
     this._buffer = [
       ...this._buffer,
-      JSON.stringify({
+      this._stringify({
         ...this._buildSplunkMeta(),
         event: finalEvent,
       }),


### PR DESCRIPTION
Allows for automatic "safe" error stringifying when logging `Error` objects.

Can be useful when logging Error objects that have circular references by reducing the stringified version of the error to a strict "safe" set of properties.